### PR TITLE
Fix CI for dual kernel distros

### DIFF
--- a/.github/workflows/build-kernel.yml
+++ b/.github/workflows/build-kernel.yml
@@ -53,7 +53,7 @@ jobs:
           packagecloud-token: ${{ secrets.PACKAGECLOUD_TOKEN }}
   
   slack-workflow-status:
-    if: ${{ matrix.arch == 'armhf' && (github.repository_owner == 'WLAN-Pi') }}
+    if: ${{ always() && (github.repository_owner == 'WLAN-Pi') && (! github.event.pull_request.head.repo.fork) }}
     name: Post Workflow Status to Slack
     needs:
       - build

--- a/.github/workflows/build-kernel.yml
+++ b/.github/workflows/build-kernel.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Upload kernel
         uses: actions/upload-artifact@v4
         with:
-          name: wlanpi-kernel-${{ steps.build-kernel.outputs.package-version }}
+          name: wlanpi-kernel-${{ matrix.distro }}-${{ steps.build-kernel.outputs.package-version }}
           path: ${{ steps.build-kernel.outputs.deb-package }}
 
       - name: Upload package to debian/${{ matrix.distro }} on packagecloud
@@ -51,9 +51,9 @@ jobs:
           packagecloud-repo: dev
           packagecloud-distrib: debian/${{ matrix.distro }}
           packagecloud-token: ${{ secrets.PACKAGECLOUD_TOKEN }}
-          
+  
   slack-workflow-status:
-    if: always()
+    if: ${{ matrix.arch == 'armhf' && (github.repository_owner == 'WLAN-Pi') }}
     name: Post Workflow Status to Slack
     needs:
       - build

--- a/.github/workflows/build-kernel.yml
+++ b/.github/workflows/build-kernel.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Upload kernel
         uses: actions/upload-artifact@v4
         with:
-          name: wlanpi-kernel-${{ matrix.distro }}-${{ steps.build-kernel.outputs.package-version }}
+          name: wlanpi-kernel-${{ steps.build-kernel.outputs.package-version }}-${{ matrix.distro }}
           path: ${{ steps.build-kernel.outputs.deb-package }}
 
       - name: Upload package to debian/${{ matrix.distro }} on packagecloud

--- a/.github/workflows/build-kernel.yml
+++ b/.github/workflows/build-kernel.yml
@@ -43,7 +43,7 @@ jobs:
           path: ${{ steps.build-kernel.outputs.deb-package }}
 
       - name: Upload package to debian/${{ matrix.distro }} on packagecloud
-        if: ${{ github.event.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
+        if: ${{ github.event.ref == format('refs/heads/{0}', github.event.repository.default_branch) && (github.repository_owner == 'WLAN-Pi') && (! github.event.pull_request.head.repo.fork) }}
         uses: danielmundi/upload-packagecloud@main
         with:
           package-name: ${{ steps.build-kernel.outputs.deb-package }}

--- a/build-kernel.sh
+++ b/build-kernel.sh
@@ -22,7 +22,7 @@ WLANPI_DEFCONFIG="wlanpi_v7l_defconfig"
 KERNEL_FORCE_SYNC="0"
 CLEAN_KERNEL="0"
 SKIP_PATCHES="0"
-DEB_ARCH="armhf"
+DEB_ARCH="arm64"
 EXEC_FUNC=""
 NUM_CORES=$(($(nproc)/2))
 export DEBFULLNAME="Daniel Finimundi"
@@ -227,7 +227,9 @@ prepare_build_package()
     (cd debian; ./gen_kernel_preinst_postinst.sh "${KERNEL_ARCH// /,}")
     dch -v "$DEBVER" -D bullseye --force-distribution "Kernel version ${KERNEL_VERSION}"
 
-    echo "::set-output name=package-version::${DEBVER}"
+    # https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
+    # echo "::set-output name=package-version::${DEBVER}"
+    echo "package-version=${DEBVER}" >> $GITHUB_OUTPUT
 }
 
 build_package()


### PR DESCRIPTION
## Type of change 

*Pick at least one.*

* [X] Bug fix (non-breaking change that fixes something)

## Proposed change

*Please describe the purpose of this change, the problem it solves, and why the change is necessary. Including code snippets or links to related documentation when applicable will assist approval.*

This PR stops use of the deprecated set-output, updates the sbuild submodule to the latest commit, and enables unique filenames allowing CI to run with multiple distros in the strategy matrix.
 
## Testing

*Please explain how you tested this change manually, and if applicable, what new tests you added.*

Tested in my fork.

## Checklist

* [X] I have read the [contribution guidelines and policies](https://github.com/WLAN-Pi/.github/blob/main/docs/contributing.md)
* [X] I have targeted this PR against the correct git branch
* [X] I linked an approved GitHub issue to this PR (in the next section). No PR without a related GH issue. Conversations about your PR efforts in other channels such as electronic mail, social media, morse code, and WLAN Pi Slack **do not count**.

## Related Issues/PRs

This PR closes issue #9