### PR TITLE
Linux kernel crash when transferring data on WLANPi Go USB accessory port

### DIFF
--- a/build-kernel.sh
+++ b/build-kernel.sh
@@ -15,10 +15,10 @@ DEB_PATH="${SCRIPT_PATH}/debian/wlanpi-kernel"
 
 # Set default values for configurations
 KERNEL_URL="https://github.com/raspberrypi/linux.git"
-KERNEL_BRANCH="rpi-6.7.y"
+KERNEL_BRANCH="rpi-6.12.y"
 KERNEL_ARCH="arm64"
 KERNEL_DEFCONFIG="bcm2711_defconfig"
-WLANPI_DEFCONFIG="wlanpi_v7l_defconfig"
+WLANPI_DEFCONFIG="wlanpi_v8_defconfig"
 KERNEL_FORCE_SYNC="0"
 CLEAN_KERNEL="0"
 SKIP_PATCHES="0"

--- a/kernel-patches/0004-packet-NAK-retry-MAX3421.patch
+++ b/kernel-patches/0004-packet-NAK-retry-MAX3421.patch
@@ -1,0 +1,28 @@
+diff -urpN a/drivers/usb/host/max3421-hcd.c b/drivers/usb/host/max3421-hcd.c
+--- a/drivers/usb/host/max3421-hcd.c    2024-12-03 23:20:52.543590786 +0000
++++ b/drivers/usb/host/max3421-hcd.c    2024-12-03 22:34:31.839613898 +0000
+@@ -72,6 +72,12 @@
+ #define USB_MAX_FRAME_NUMBER   0x7ff
+ #define USB_MAX_RETRIES                3 /* # of retries before error is reported */
+
++/*
++ * Max. # of times we're willing to retransmit a request immediately in
++ * resposne to a NAK.  Afterwards, we fall back on trying once a frame.
++ */
++#define NAK_MAX_FAST_RETRANSMITS       2
++
+ #define POWER_BUDGET   500     /* in mA; use 8 for low-power port testing */
+
+ /* Port-change mask: */
+@@ -918,8 +924,11 @@ max3421_handle_error(struct usb_hcd *hcd
+                 * Device wasn't ready for data or has no data
+                 * available: retry the packet again.
+                 */
++               if (max3421_ep->naks++ < NAK_MAX_FAST_RETRANSMITS) {
+                max3421_next_transfer(hcd, 1);
+                switch_sndfifo = 0;
++               } else
++                       max3421_slow_retransmit(hcd);
+                break;
+        }
+        if (switch_sndfifo)

--- a/wlanpi_v8_defconfig
+++ b/wlanpi_v8_defconfig
@@ -1,4 +1,12 @@
 CONFIG_LOCALVERSION="-v8-wlanpi"
+
+# WLAN Pi Go
+#
+CONFIG_USB_SUPPORT=y
+CONFIG_USB=y
+CONFIG_SPI=y
+CONFIG_USB_MAX3421_HCD=m
+
 #
 # Classification
 #


### PR DESCRIPTION
## Type of change 

* [x] Bug fix (non-breaking change that fixes something)

## Checklist

* [x] I have read the [contribution guidelines and policies](https://github.com/WLAN-Pi/.github/blob/main/docs/contributing.md)
* [x] I have targeted this PR against the correct git branch
* [x] I ran the test suite and verified it succeeded
* [x] I linked an approved GitHub issue to this PR (in the next section). No PR without a related GH issue. Conversations about your PR efforts in other channels such as electronic mail, social media, morse code, and WLAN Pi Slack **do not count**.
* [x] I have updated the changelog (if applicable)
* [x] I have added or updated the documentation (if applicable)

- This PR fixes/closes issue #14 