### PR TITLE
Add fallback boot directory detection and cross-compile kernel with Debian-compatible headers for module building

### DIFF
--- a/.github/workflows/build_kernel_bookworm.yml
+++ b/.github/workflows/build_kernel_bookworm.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
 
     env:
       DISTRO: bookworm

--- a/.github/workflows/build_kernel_bookworm.yml
+++ b/.github/workflows/build_kernel_bookworm.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: cache-apt
-          key: ${{ runner.os }}-apt-${{ hashFiles('**/build-kernel.sh') }}
+          key: ${{ runner.os }}-apt-${{ hashFiles('build-kernel.sh') }}
           restore-keys: |
             ${{ runner.os }}-apt-
 
@@ -51,7 +51,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: linux
-          key: ${{ runner.os }}-kernel-${{ hashFiles('**/build-kernel.sh') }}
+          key: ${{ runner.os }}-kernel-${{ hashFiles('build-kernel.sh') }}
           restore-keys: |
             ${{ runner.os }}-kernel-
 

--- a/build-kernel.sh
+++ b/build-kernel.sh
@@ -37,7 +37,6 @@ HEADERS_OUTPUT_DIR="$OUTPUT_PATH/linux-headers"
 
 # Debian Package Metadata
 PACKAGE_NAME="wlanpi-kernel-bookworm"
-HEADERS_PACKAGE_NAME="wlanpi-kernel-headers-bookworm"
 
 # Trap for error handling
 trap 'echo "Error encountered at line $LINENO. Exiting."; exit 1' ERR
@@ -121,29 +120,6 @@ cp arch/arm64/boot/Image "$IMAGE_OUTPUT"
 find arch/arm64/boot/dts/ -name '*.dtb' -exec cp {} "$DTB_OUTPUT_DIR" \;
 find arch/arm64/boot/dts/overlays/ -name '*.dtbo' -exec cp {} "$DTBO_OUTPUT_DIR" \;
 
-prepare_kernel_headers() {
-    echo "Preparing kernel headers..."
-    
-    mkdir -p "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION"
-    mkdir -p "$HEADERS_OUTPUT_DIR/lib/modules/$KERNEL_VERSION/build"
-
-    echo "Copying kernel headers..."
-    make ARCH="$ARCH" CROSS_COMPILE="$CROSS_COMPILE" \
-        INSTALL_HDR_PATH="$HEADERS_OUTPUT_DIR/usr" \
-        headers_install
-
-    echo "Copying kernel source for headers..."
-    cp -a "include" "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION/"
-    cp -a "arch/$ARCH/include" "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION/arch/"
-    
-    cp Makefile "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION/"
-    cp .config "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION/"
-    cp -a scripts "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION/"
-
-    ln -sf "/usr/src/linux-headers-$KERNEL_VERSION" \
-        "$HEADERS_OUTPUT_DIR/lib/modules/$KERNEL_VERSION/build"
-}
-
 # Prepare Debian package
 echo "Preparing Debian package..."
 
@@ -151,6 +127,8 @@ echo "Preparing Debian package..."
 KERNEL_VERSION=$(make kernelrelease)
 BUILD_DATE=$(date +%Y%m%d)
 PACKAGE_VERSION="${KERNEL_VERSION}-${BUILD_DATE}"
+
+HEADERS_PACKAGE_NAME="linux-headers-${KERNEL_VERSION}"
 
 echo "Kernel Version: $KERNEL_VERSION"
 echo "Build Date: $BUILD_DATE"
@@ -242,7 +220,39 @@ EOF
 # Make postinst script executable
 chmod 755 "$PACKAGE_DIR/DEBIAN/postinst"
 
-prepare_kernel_headers
+# Prepare kernel headers
+echo "Preparing kernel headers..."
+
+mkdir -p "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION"
+mkdir -p "$HEADERS_OUTPUT_DIR/lib/modules/$KERNEL_VERSION/build"
+
+echo "Copying kernel headers..."
+make ARCH="$ARCH" CROSS_COMPILE="$CROSS_COMPILE" \
+    INSTALL_HDR_PATH="$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION" \
+    headers_install
+
+echo "Copying kernel source for headers..."
+cp -a "include" "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION/"
+cp -a "arch/$ARCH/include" "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION/arch/$ARCH/"
+
+cp Makefile "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION/"
+cp .config "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION/"
+cp Module.symvers "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION/"
+cp System.map "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION/"
+
+[ -f Module.order ] && cp Module.order "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION/"
+
+cp -a scripts "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION/"
+cp -a tools "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION/"
+
+mkdir -p "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION/arch/$ARCH"
+cp -a arch/$ARCH/Makefile "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION/arch/$ARCH/"
+
+find arch/$ARCH -name "*.S" -o -name "Kbuild" | \
+    cpio -pdm "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION/" 2>/dev/null || true
+
+ln -sf "/usr/src/linux-headers-$KERNEL_VERSION" \
+    "$HEADERS_OUTPUT_DIR/lib/modules/$KERNEL_VERSION/build"
 
 # Create headers package directory
 HEADERS_PACKAGE_DIR="$BASE_DIR/wlanpi-kernel-headers-package"
@@ -271,16 +281,16 @@ Description: Linux kernel headers for WLAN Pi Raspberry Pi kernel
 EOF
 
 # Create DEBIAN/postinst script for headers
-cat <<'EOF' > "$HEADERS_PACKAGE_DIR/DEBIAN/postinst"
+cat <<EOF > "$HEADERS_PACKAGE_DIR/DEBIAN/postinst"
 #!/bin/bash
 set -e
 
-KERNEL_VERSION="$2"
+KERNEL_VERSION="$KERNEL_VERSION"
 
 # Update module build symlink
-if [ -d "/usr/src/linux-headers-$KERNEL_VERSION" ]; then
-    rm -f "/lib/modules/$KERNEL_VERSION/build"
-    ln -sf "/usr/src/linux-headers-$KERNEL_VERSION" "/lib/modules/$KERNEL_VERSION/build"
+if [ -d "/usr/src/linux-headers-\$KERNEL_VERSION" ]; then
+    rm -f "/lib/modules/\$KERNEL_VERSION/build"
+    ln -sf "/usr/src/linux-headers-\$KERNEL_VERSION" "/lib/modules/\$KERNEL_VERSION/build"
 fi
 
 exit 0

--- a/build-kernel.sh
+++ b/build-kernel.sh
@@ -292,8 +292,8 @@ done
 
 sudo mount --bind "$KERNEL_SRC_DIR" "$CHROOT_DIR/mnt"
 
-echo "Building scripts in Debian chroot..."
-sudo chroot "$CHROOT_DIR" /bin/bash -c "cd /mnt && make scripts" || {
+echo "Building scripts and module tools in Debian chroot..."
+sudo chroot "$CHROOT_DIR" /bin/bash -c "cd /mnt && make modules_prepare" || {
     echo "ERROR: Failed to build scripts in chroot"
     sudo umount "$CHROOT_DIR/mnt" || true
     exit 1

--- a/build-kernel.sh
+++ b/build-kernel.sh
@@ -251,6 +251,15 @@ else
     echo "Verified: .config copied successfully"
 fi
 
+echo "Generating configuration files for module builds..."
+make ARCH="$ARCH" CROSS_COMPILE="$CROSS_COMPILE" modules_prepare
+
+echo "Copying generated configuration files..."
+cp -a include/generated "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION/include/"
+cp -a include/config "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION/include/"
+mkdir -p "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION/arch/$ARCH/include/generated"
+cp -a arch/$ARCH/include/generated/* "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION/arch/$ARCH/include/generated/" 2>/dev/null || true
+
 cp Module.symvers "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION/"
 cp System.map "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION/"
 

--- a/build-kernel.sh
+++ b/build-kernel.sh
@@ -343,11 +343,14 @@ if [ -d "/usr/src/linux-headers-\$KERNEL_VERSION" ]; then
     ln -sf "/usr/src/linux-headers-\$KERNEL_VERSION" "/lib/modules/\$KERNEL_VERSION/build"
 fi
 
-# Rebuild scripts for target system
+# Rebuild build tools with correct GLIBC and generate required headers
 if [ -d "/usr/src/linux-headers-\$KERNEL_VERSION/scripts" ]; then
     echo "Rebuilding kernel build scripts for target system..."
-    make -C "/usr/src/linux-headers-\$KERNEL_VERSION" scripts 2>/dev/null || true
-    make -C "/usr/src/linux-headers-\$KERNEL_VERSION" modules_prepare 2>/dev/null || true
+    NCPUS=\$(nproc)
+    JOBS=\$((NCPUS > 1 ? NCPUS - 1 : 1))
+    make -j\$JOBS -C "/usr/src/linux-headers-\$KERNEL_VERSION" scripts 2>/dev/null || true
+    echo "Generating module build configuration..."
+    make -j\$JOBS -C "/usr/src/linux-headers-\$KERNEL_VERSION" modules_prepare 2>/dev/null || true
 fi
 
 exit 0

--- a/build-kernel.sh
+++ b/build-kernel.sh
@@ -301,10 +301,8 @@ sudo chroot "$CHROOT_DIR" /bin/bash -c "cd /mnt && make modules_prepare" || {
 
 sudo umount "$CHROOT_DIR/mnt"
 
-# Verify modpost was rebuilt with correct GLIBC
-if ! ldd "$KERNEL_SRC_DIR/scripts/mod/modpost" | grep -q "GLIBC_2.3"; then
-    echo "ERROR: modpost still has wrong GLIBC dependency"
-    ldd "$KERNEL_SRC_DIR/scripts/mod/modpost"
+if ! ldd "$KERNEL_SRC_DIR/scripts/mod/modpost" | grep -q "libc.so.6"; then
+    echo "ERROR: modpost not properly linked"
     exit 1
 fi
 

--- a/build-kernel.sh
+++ b/build-kernel.sh
@@ -254,6 +254,11 @@ fi
 echo "Generating configuration files for module builds..."
 make ARCH="$ARCH" CROSS_COMPILE="$CROSS_COMPILE" modules_prepare
 
+if [ ! -f "include/generated/autoconf.h" ]; then
+    echo "ERROR: modules_prepare did not generate autoconf.h!"
+    exit 1
+fi
+
 echo "Copying generated configuration files..."
 cp -a include/generated "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION/include/"
 cp -a include/config "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION/include/"

--- a/build-kernel.sh
+++ b/build-kernel.sh
@@ -304,16 +304,10 @@ mkdir -p "$HEADERS_PACKAGE_DIR/DEBIAN" \
 # Copy headers to package directory
 cp -r "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION/." \
     "$HEADERS_PACKAGE_DIR/usr/src/linux-headers-$KERNEL_VERSION/"
-cp -r "$HEADERS_OUTPUT_DIR/lib/modules/$KERNEL_VERSION/build" \
-    "$HEADERS_PACKAGE_DIR/lib/modules/$KERNEL_VERSION/"
 
-if [ ! -f "$HEADERS_PACKAGE_DIR/usr/src/linux-headers-$KERNEL_VERSION/include/generated/autoconf.h" ]; then
-    echo "ERROR: autoconf.h not in final package directory!"
-    ls -la "$HEADERS_PACKAGE_DIR/usr/src/linux-headers-$KERNEL_VERSION/include/generated/" || echo "generated/ doesn't exist"
-    exit 1
-else
-    echo "SUCCESS: autoconf.h is in final package directory"
-fi
+mkdir -p "$HEADERS_PACKAGE_DIR/lib/modules/$KERNEL_VERSION"
+ln -sf "/usr/src/linux-headers-$KERNEL_VERSION" \
+    "$HEADERS_PACKAGE_DIR/lib/modules/$KERNEL_VERSION/build"
 
 # Create DEBIAN/control file for headers package
 cat <<EOF > "$HEADERS_PACKAGE_DIR/DEBIAN/control"

--- a/build-kernel.sh
+++ b/build-kernel.sh
@@ -243,13 +243,7 @@ cp -a "arch/$ARCH/include" "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VE
 
 cp Makefile "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION/"
 cp .config "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION/"
-
-if [ ! -f "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION/.config" ]; then
-    echo "ERROR: .config file was not copied!"
-    exit 1
-else
-    echo "Verified: .config copied successfully"
-fi
+cp Kconfig "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION/"
 
 echo "Generating configuration files for module builds..."
 make ARCH="$ARCH" CROSS_COMPILE="$CROSS_COMPILE" modules_prepare

--- a/build-kernel.sh
+++ b/build-kernel.sh
@@ -246,14 +246,26 @@ cp .config "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION/"
 cp Kconfig "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION/"
 
 echo "Copying Kconfig files..."
-find . -name "Kconfig*" -type f -exec cp --parents {} "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION/" \;
+find . -name "Kconfig*" -type f | tar cf - -T - | tar xf - -C "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION/"
 
 echo "Generating configuration files for module builds..."
 make ARCH="$ARCH" CROSS_COMPILE="$CROSS_COMPILE" modules_prepare
 
+if [ ! -f "include/generated/autoconf.h" ]; then
+    echo "ERROR: modules_prepare did not generate autoconf.h in source!"
+    ls -la include/generated/
+    exit 1
+fi
+
 echo "Copying generated configuration files..."
 cp -a include/generated "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION/include/"
 cp -a include/config "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION/include/"
+
+if [ ! -f "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION/include/generated/autoconf.h" ]; then
+    echo "ERROR: autoconf.h not in staging!"
+    ls -la "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION/include/generated/"
+    exit 1
+fi
 
 mkdir -p "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION/arch/$ARCH/include/generated"
 cp -a arch/$ARCH/include/generated/* "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION/arch/$ARCH/include/generated/" 2>/dev/null || true
@@ -291,6 +303,14 @@ cp -r "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION/." \
     "$HEADERS_PACKAGE_DIR/usr/src/linux-headers-$KERNEL_VERSION/"
 cp -r "$HEADERS_OUTPUT_DIR/lib/modules/$KERNEL_VERSION/build" \
     "$HEADERS_PACKAGE_DIR/lib/modules/$KERNEL_VERSION/"
+
+if [ ! -f "$HEADERS_PACKAGE_DIR/usr/src/linux-headers-$KERNEL_VERSION/include/generated/autoconf.h" ]; then
+    echo "ERROR: autoconf.h not in final package directory!"
+    ls -la "$HEADERS_PACKAGE_DIR/usr/src/linux-headers-$KERNEL_VERSION/include/generated/" || echo "generated/ doesn't exist"
+    exit 1
+else
+    echo "SUCCESS: autoconf.h is in final package directory"
+fi
 
 # Create DEBIAN/control file for headers package
 cat <<EOF > "$HEADERS_PACKAGE_DIR/DEBIAN/control"

--- a/build-kernel.sh
+++ b/build-kernel.sh
@@ -129,7 +129,7 @@ echo "Preparing Debian package..."
 # Retrieve kernel version and set package version
 KERNEL_VERSION=$(make kernelrelease)
 BUILD_DATE=$(date +%Y%m%d)
-PACKAGE_VERSION="${KERNEL_VERSION}-${BUILD_DATE}"
+PACKAGE_VERSION="${BUILD_DATE}"
 
 HEADERS_PACKAGE_NAME="linux-headers-${KERNEL_VERSION}"
 

--- a/build-kernel.sh
+++ b/build-kernel.sh
@@ -285,6 +285,11 @@ cp -a tools "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION/"
 
 cp -a arch/$ARCH/Makefile "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION/arch/$ARCH/"
 
+if [ -d "arch/$ARCH/tools" ]; then
+    echo "Copying arch-specific tools..."
+    cp -a arch/$ARCH/tools "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION/arch/$ARCH/"
+fi
+
 find arch/$ARCH -name "*.S" -o -name "Kbuild" | \
     cpio -pdm "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION/" 2>/dev/null || true
 

--- a/build-kernel.sh
+++ b/build-kernel.sh
@@ -262,6 +262,15 @@ fi
 echo "Copying generated configuration files..."
 cp -a include/generated "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION/include/"
 cp -a include/config "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION/include/"
+
+if [ ! -f "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION/include/generated/autoconf.h" ]; then
+    echo "ERROR: autoconf.h was not copied to staging directory!"
+    ls -la "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION/include/generated/"
+    exit 1
+else
+    echo "Verified: autoconf.h copied to staging directory"
+fi
+
 mkdir -p "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION/arch/$ARCH/include/generated"
 cp -a arch/$ARCH/include/generated/* "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION/arch/$ARCH/include/generated/" 2>/dev/null || true
 

--- a/build-kernel.sh
+++ b/build-kernel.sh
@@ -282,10 +282,15 @@ sudo debootstrap --arch=arm64 bookworm "$CHROOT_DIR" http://deb.debian.org/debia
 sudo chroot "$CHROOT_DIR" apt-get update
 sudo chroot "$CHROOT_DIR" apt-get install -y build-essential bc bison flex libssl-dev libelf-dev
 
-sudo mount --bind "$KERNEL_SRC_DIR" "$CHROOT_DIR/mnt"
+echo "Removing Ubuntu-built script binaries..."
+find "$KERNEL_SRC_DIR/scripts" -type f -executable | while read f; do
+    if file "$f" | grep -q "ELF"; then
+        rm -f "$f"
+        echo "Removed: $f"
+    fi
+done
 
-# Clean scripts directory to force rebuild
-sudo chroot "$CHROOT_DIR" /bin/bash -c "cd /mnt && make scripts/clean" || true
+sudo mount --bind "$KERNEL_SRC_DIR" "$CHROOT_DIR/mnt"
 
 echo "Building scripts in Debian chroot..."
 sudo chroot "$CHROOT_DIR" /bin/bash -c "cd /mnt && make scripts" || {
@@ -293,6 +298,11 @@ sudo chroot "$CHROOT_DIR" /bin/bash -c "cd /mnt && make scripts" || {
     sudo umount "$CHROOT_DIR/mnt" || true
     exit 1
 }
+
+if ! chroot "$CHROOT_DIR" ldd /mnt/scripts/mod/modpost | grep -q "libc.so.6"; then
+    echo "ERROR: modpost not properly linked"
+    exit 1
+fi
 
 sudo umount "$CHROOT_DIR/mnt"
 

--- a/build-kernel.sh
+++ b/build-kernel.sh
@@ -234,8 +234,7 @@ mkdir -p "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION/arch/$ARCH"
 
 echo "Copying kernel headers..."
 make ARCH="$ARCH" CROSS_COMPILE="$CROSS_COMPILE" \
-    INSTALL_HDR_PATH="$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION" \
-    headers_install
+    INSTALL_HDR_PATH="$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION"
 
 echo "Copying kernel source for headers..."
 cp -a "include" "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION/"

--- a/build-kernel.sh
+++ b/build-kernel.sh
@@ -294,7 +294,7 @@ KERNEL_VERSION="$KERNEL_VERSION"
 
 # Update module build symlink
 if [ -d "/usr/src/linux-headers-\$KERNEL_VERSION" ]; then
-    rm -f "/lib/modules/\$KERNEL_VERSION/build"
+    rm -rf "/lib/modules/\$KERNEL_VERSION/build"
     ln -sf "/usr/src/linux-headers-\$KERNEL_VERSION" "/lib/modules/\$KERNEL_VERSION/build"
 fi
 
@@ -306,11 +306,11 @@ chmod 755 "$HEADERS_PACKAGE_DIR/DEBIAN/postinst"
 
 # Build the Debian package
 echo "Building Debian package..."
-dpkg-deb --build "$PACKAGE_DIR" "$OUTPUT_PATH/${PACKAGE_NAME}_${PACKAGE_VERSION}_arm64.deb"
+fakeroot dpkg-deb --build "$PACKAGE_DIR" "$OUTPUT_PATH/${PACKAGE_NAME}_${PACKAGE_VERSION}_arm64.deb"
 
 # Build the headers Debian package
 echo "Building Kernel Headers Debian package..."
-dpkg-deb --build "$HEADERS_PACKAGE_DIR" \
+fakeroot dpkg-deb --build "$HEADERS_PACKAGE_DIR" \
     "$OUTPUT_PATH/${HEADERS_PACKAGE_NAME}_${HEADERS_PACKAGE_VERSION}_arm64.deb"
 
 echo "Debian packages created successfully in $OUTPUT_PATH:"

--- a/build-kernel.sh
+++ b/build-kernel.sh
@@ -245,6 +245,9 @@ cp Makefile "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION/"
 cp .config "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION/"
 cp Kconfig "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION/"
 
+echo "Copying Kconfig files..."
+find . -name "Kconfig*" -type f -exec cp --parents {} "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION/" \;
+
 echo "Generating configuration files for module builds..."
 make ARCH="$ARCH" CROSS_COMPILE="$CROSS_COMPILE" modules_prepare
 

--- a/build-kernel.sh
+++ b/build-kernel.sh
@@ -129,7 +129,8 @@ echo "Preparing Debian package..."
 # Retrieve kernel version and set package version
 KERNEL_VERSION=$(make kernelrelease)
 BUILD_DATE=$(date +%Y%m%d)
-PACKAGE_VERSION="${BUILD_DATE}"
+PACKAGE_VERSION="${KERNEL_VERSION}-${BUILD_DATE}"  
+HEADERS_PACKAGE_VERSION="${BUILD_DATE}" 
 
 HEADERS_PACKAGE_NAME="linux-headers-${KERNEL_VERSION}"
 
@@ -309,11 +310,11 @@ dpkg-deb --build "$PACKAGE_DIR" "$OUTPUT_PATH/${PACKAGE_NAME}_${PACKAGE_VERSION}
 # Build the headers Debian package
 echo "Building Kernel Headers Debian package..."
 dpkg-deb --build "$HEADERS_PACKAGE_DIR" \
-    "$OUTPUT_PATH/${HEADERS_PACKAGE_NAME}_${PACKAGE_VERSION}_arm64.deb"
+    "$OUTPUT_PATH/${HEADERS_PACKAGE_NAME}_${HEADERS_PACKAGE_VERSION}_arm64.deb"
 
 echo "Debian packages created successfully in $OUTPUT_PATH:"
 echo "- ${PACKAGE_NAME}_${PACKAGE_VERSION}_arm64.deb"
-echo "- ${HEADERS_PACKAGE_NAME}_${PACKAGE_VERSION}_arm64.deb"
+echo "- ${HEADERS_PACKAGE_NAME}_${HEADERS_PACKAGE_VERSION}_arm64.deb"
 
 # Clean up temporary package directories
 echo "Cleaning up temporary package directories..."

--- a/build-kernel.sh
+++ b/build-kernel.sh
@@ -150,6 +150,7 @@ cp "$IMAGE_OUTPUT" "$PACKAGE_DIR/usr/local/lib/wlanpi-kernel/boot/firmware/"
 cp "$DTB_OUTPUT_DIR"*.dtb "$PACKAGE_DIR/usr/local/lib/wlanpi-kernel/boot/firmware/"
 cp "$DTBO_OUTPUT_DIR"*.dtbo "$PACKAGE_DIR/usr/local/lib/wlanpi-kernel/boot/firmware/overlays/"
 cp -r "$MODULES_OUTPUT_DIR/$KERNEL_VERSION" "$PACKAGE_DIR/lib/modules/."
+rm -f "$PACKAGE_DIR/lib/modules/$KERNEL_VERSION/build"
 
 # Create DEBIAN/control file
 cat <<EOF > "$PACKAGE_DIR/DEBIAN/control"

--- a/build-kernel.sh
+++ b/build-kernel.sh
@@ -191,7 +191,14 @@ cat <<'EOF' > "$PACKAGE_DIR/DEBIAN/postinst"
 set -e
 
 # Variables
-FIRMWARE_DIR="/boot/firmware"
+if [ -d "/boot/firmware" ]; then
+    FIRMWARE_DIR="/boot/firmware"
+elif [ -d "/boot" ]; then
+    FIRMWARE_DIR="/boot"
+else
+    echo "Error: Neither /boot/firmware nor /boot directory found" >&2
+    exit 1
+fi
 PACKAGE_KERNEL_DIR="/usr/local/lib/wlanpi-kernel/boot/firmware"
 CONFIG_TXT="$FIRMWARE_DIR/config.txt"
 KERNEL_IMAGE="wlanpi-kernel8.img"

--- a/build-kernel.sh
+++ b/build-kernel.sh
@@ -251,38 +251,17 @@ find . -name "Kconfig*" -type f | tar cf - -T - | tar xf - -C "$HEADERS_OUTPUT_D
 echo "Generating configuration files for module builds..."
 make ARCH="$ARCH" CROSS_COMPILE="$CROSS_COMPILE" modules_prepare
 
-if [ ! -f "include/generated/autoconf.h" ]; then
-    echo "ERROR: modules_prepare did not generate autoconf.h in source!"
-    ls -la include/generated/
-    exit 1
-fi
-
 echo "Copying generated configuration files..."
 cp -a include/generated "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION/include/"
 cp -a include/config "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION/include/"
-
-if [ ! -f "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION/include/generated/autoconf.h" ]; then
-    echo "ERROR: autoconf.h not in staging!"
-    ls -la "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION/include/generated/"
-    exit 1
-fi
-
 mkdir -p "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION/arch/$ARCH/include/generated"
 cp -a arch/$ARCH/include/generated/* "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION/arch/$ARCH/include/generated/" 2>/dev/null || true
 
 cp Module.symvers "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION/"
 cp System.map "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION/"
-
 [ -f Module.order ] && cp Module.order "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION/"
 
-cp -a scripts "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION/"
-
-echo "Removing precompiled script binaries..."
-find "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION/scripts" -type f -executable -exec file {} \; | \
-    grep -i ELF | cut -d: -f1 | xargs rm -f
-
 cp -a tools "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION/"
-
 cp -a arch/$ARCH/Makefile "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION/arch/$ARCH/"
 
 if [ -d "arch/$ARCH/tools" ]; then
@@ -292,6 +271,25 @@ fi
 
 find arch/$ARCH -name "*.S" -o -name "Kbuild" | \
     cpio -pdm "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION/" 2>/dev/null || true
+
+echo "Rebuilding scripts with Debian GLIBC compatibility..."
+
+sudo apt-get update && sudo apt-get install -y debootstrap
+
+CHROOT_DIR="$BASE_DIR/debian-chroot"
+sudo debootstrap --arch=arm64 bookworm "$CHROOT_DIR" http://deb.debian.org/debian
+
+sudo chroot "$CHROOT_DIR" apt-get update
+sudo chroot "$CHROOT_DIR" apt-get install -y build-essential bc bison flex libssl-dev libelf-dev
+
+sudo mount --bind "$KERNEL_SRC_DIR" "$CHROOT_DIR/mnt"
+
+# Rebuild scripts inside Debian environment
+sudo chroot "$CHROOT_DIR" /bin/bash -c "cd /mnt && make ARCH=arm64 scripts"
+
+sudo umount "$CHROOT_DIR/mnt"
+
+cp -a scripts "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION/"
 
 ln -sf "/usr/src/linux-headers-$KERNEL_VERSION" \
     "$HEADERS_OUTPUT_DIR/lib/modules/$KERNEL_VERSION/build"
@@ -329,35 +327,6 @@ Depends: $PACKAGE_NAME (= $PACKAGE_VERSION), gcc, make, perl
 Description: Linux kernel headers for WLAN Pi Raspberry Pi kernel
  Kernel header files and scripts for WLAN Pi custom kernel development.
 EOF
-
-# Create DEBIAN/postinst script for headers
-cat <<EOF > "$HEADERS_PACKAGE_DIR/DEBIAN/postinst"
-#!/bin/bash
-set -e
-
-KERNEL_VERSION="$KERNEL_VERSION"
-
-# Update module build symlink
-if [ -d "/usr/src/linux-headers-\$KERNEL_VERSION" ]; then
-    rm -rf "/lib/modules/\$KERNEL_VERSION/build"
-    ln -sf "/usr/src/linux-headers-\$KERNEL_VERSION" "/lib/modules/\$KERNEL_VERSION/build"
-fi
-
-# Rebuild build tools with correct GLIBC and generate required headers
-if [ -d "/usr/src/linux-headers-\$KERNEL_VERSION/scripts" ]; then
-    echo "Rebuilding kernel build scripts for target system..."
-    NCPUS=\$(nproc)
-    JOBS=\$((NCPUS > 1 ? NCPUS - 1 : 1))
-    make -j\$JOBS -C "/usr/src/linux-headers-\$KERNEL_VERSION" scripts 2>/dev/null || true
-    echo "Generating module build configuration..."
-    make -j\$JOBS -C "/usr/src/linux-headers-\$KERNEL_VERSION" modules_prepare 2>/dev/null || true
-fi
-
-exit 0
-EOF
-
-# Make postinst script executable
-chmod 755 "$HEADERS_PACKAGE_DIR/DEBIAN/postinst"
 
 # Build the Debian package
 echo "Building Debian package..."

--- a/build-kernel.sh
+++ b/build-kernel.sh
@@ -243,6 +243,14 @@ cp -a "arch/$ARCH/include" "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VE
 
 cp Makefile "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION/"
 cp .config "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION/"
+
+if [ ! -f "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION/.config" ]; then
+    echo "ERROR: .config file was not copied!"
+    exit 1
+else
+    echo "Verified: .config copied successfully"
+fi
+
 cp Module.symvers "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION/"
 cp System.map "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION/"
 
@@ -296,6 +304,12 @@ KERNEL_VERSION="$KERNEL_VERSION"
 if [ -d "/usr/src/linux-headers-\$KERNEL_VERSION" ]; then
     rm -rf "/lib/modules/\$KERNEL_VERSION/build"
     ln -sf "/usr/src/linux-headers-\$KERNEL_VERSION" "/lib/modules/\$KERNEL_VERSION/build"
+fi
+
+# Rebuild scripts for target system
+if [ -d "/usr/src/linux-headers-\$KERNEL_VERSION/scripts" ]; then
+    echo "Rebuilding kernel build scripts for target system..."
+    make -C "/usr/src/linux-headers-\$KERNEL_VERSION" scripts 2>/dev/null || true
 fi
 
 exit 0

--- a/build-kernel.sh
+++ b/build-kernel.sh
@@ -299,12 +299,14 @@ sudo chroot "$CHROOT_DIR" /bin/bash -c "cd /mnt && make scripts" || {
     exit 1
 }
 
-if ! chroot "$CHROOT_DIR" ldd /mnt/scripts/mod/modpost | grep -q "libc.so.6"; then
-    echo "ERROR: modpost not properly linked"
+sudo umount "$CHROOT_DIR/mnt"
+
+# Verify modpost was rebuilt with correct GLIBC
+if ! ldd "$KERNEL_SRC_DIR/scripts/mod/modpost" | grep -q "GLIBC_2.3"; then
+    echo "ERROR: modpost still has wrong GLIBC dependency"
+    ldd "$KERNEL_SRC_DIR/scripts/mod/modpost"
     exit 1
 fi
-
-sudo umount "$CHROOT_DIR/mnt"
 
 cp -a scripts "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION/"
 

--- a/build-kernel.sh
+++ b/build-kernel.sh
@@ -284,8 +284,15 @@ sudo chroot "$CHROOT_DIR" apt-get install -y build-essential bc bison flex libss
 
 sudo mount --bind "$KERNEL_SRC_DIR" "$CHROOT_DIR/mnt"
 
-# Rebuild scripts inside Debian environment
-sudo chroot "$CHROOT_DIR" /bin/bash -c "cd /mnt && make ARCH=arm64 scripts"
+# Clean scripts directory to force rebuild
+sudo chroot "$CHROOT_DIR" /bin/bash -c "cd /mnt && make scripts/clean" || true
+
+echo "Building scripts in Debian chroot..."
+sudo chroot "$CHROOT_DIR" /bin/bash -c "cd /mnt && make scripts" || {
+    echo "ERROR: Failed to build scripts in chroot"
+    sudo umount "$CHROOT_DIR/mnt" || true
+    exit 1
+}
 
 sudo umount "$CHROOT_DIR/mnt"
 

--- a/build-kernel.sh
+++ b/build-kernel.sh
@@ -225,6 +225,7 @@ echo "Preparing kernel headers..."
 
 mkdir -p "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION"
 mkdir -p "$HEADERS_OUTPUT_DIR/lib/modules/$KERNEL_VERSION/build"
+mkdir -p "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION/arch/$ARCH"
 
 echo "Copying kernel headers..."
 make ARCH="$ARCH" CROSS_COMPILE="$CROSS_COMPILE" \
@@ -245,7 +246,6 @@ cp System.map "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION/"
 cp -a scripts "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION/"
 cp -a tools "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION/"
 
-mkdir -p "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION/arch/$ARCH"
 cp -a arch/$ARCH/Makefile "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION/arch/$ARCH/"
 
 find arch/$ARCH -name "*.S" -o -name "Kbuild" | \

--- a/build-kernel.sh
+++ b/build-kernel.sh
@@ -69,6 +69,9 @@ cd "$KERNEL_SRC_DIR"
 export ARCH="$ARCH"
 export CROSS_COMPILE="$CROSS_COMPILE"
 
+echo "Cleaning previous build artifacts..."
+make mrproper
+
 echo "Loading base config: $BASE_CONFIG..."
 make "$BASE_CONFIG"
 

--- a/build-kernel.sh
+++ b/build-kernel.sh
@@ -254,22 +254,9 @@ fi
 echo "Generating configuration files for module builds..."
 make ARCH="$ARCH" CROSS_COMPILE="$CROSS_COMPILE" modules_prepare
 
-if [ ! -f "include/generated/autoconf.h" ]; then
-    echo "ERROR: modules_prepare did not generate autoconf.h!"
-    exit 1
-fi
-
 echo "Copying generated configuration files..."
 cp -a include/generated "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION/include/"
 cp -a include/config "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION/include/"
-
-if [ ! -f "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION/include/generated/autoconf.h" ]; then
-    echo "ERROR: autoconf.h was not copied to staging directory!"
-    ls -la "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION/include/generated/"
-    exit 1
-else
-    echo "Verified: autoconf.h copied to staging directory"
-fi
 
 mkdir -p "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION/arch/$ARCH/include/generated"
 cp -a arch/$ARCH/include/generated/* "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION/arch/$ARCH/include/generated/" 2>/dev/null || true
@@ -338,6 +325,7 @@ fi
 if [ -d "/usr/src/linux-headers-\$KERNEL_VERSION/scripts" ]; then
     echo "Rebuilding kernel build scripts for target system..."
     make -C "/usr/src/linux-headers-\$KERNEL_VERSION" scripts 2>/dev/null || true
+    make -C "/usr/src/linux-headers-\$KERNEL_VERSION" modules_prepare 2>/dev/null || true
 fi
 
 exit 0

--- a/build-kernel.sh
+++ b/build-kernel.sh
@@ -257,6 +257,11 @@ cp System.map "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION/"
 [ -f Module.order ] && cp Module.order "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION/"
 
 cp -a scripts "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION/"
+
+echo "Removing precompiled script binaries..."
+find "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION/scripts" -type f -executable -exec file {} \; | \
+    grep -i ELF | cut -d: -f1 | xargs rm -f
+
 cp -a tools "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION/"
 
 cp -a arch/$ARCH/Makefile "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION/arch/$ARCH/"
@@ -275,7 +280,7 @@ mkdir -p "$HEADERS_PACKAGE_DIR/DEBIAN" \
          "$HEADERS_PACKAGE_DIR/lib/modules/$KERNEL_VERSION"
 
 # Copy headers to package directory
-cp -r "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION"/* \
+cp -r "$HEADERS_OUTPUT_DIR/usr/src/linux-headers-$KERNEL_VERSION/." \
     "$HEADERS_PACKAGE_DIR/usr/src/linux-headers-$KERNEL_VERSION/"
 cp -r "$HEADERS_OUTPUT_DIR/lib/modules/$KERNEL_VERSION/build" \
     "$HEADERS_PACKAGE_DIR/lib/modules/$KERNEL_VERSION/"


### PR DESCRIPTION
## Type of change 

<!--
Feel free to remove sections and items that don't pertain to the context of your PR.
For example, if you're updating docs, you don't need the testing section.
Note that you do not need to delete these HTML comments as they are not visible after the PR is submitted.
-->

<!-- *Pick at least one.* -->

* [X] Bug fix (non-breaking change that fixes something)
* [ ] Documentation update (readme, changelog, man page, etc.)
* [ ] New feature (non-breaking change adding functionality)
* [ ] Breaking change (fix or feature changing existing functionality)
* [ ] Code quality improvement (refactor, performance improvements)
* [ ] Other (please specify):

## Proposed change

<!-- *Please describe the purpose of this change, the problem it solves, and why the change is necessary. Including code snippets or links to related documentation when applicable will assist approval.* -->

Implements cross-compilation workflow for ARM64 kernel with functional kernel headers package that supports building out-of-tree modules on Debian Bookworm systems.

Kernel package:

- Add fallback boot directory detection (/boot/firmware or /boot)

Header package:

- Rename to standard linux-headers-{version} format for apt compatibility
- Include required files for module builds (Module.symvers, System.map, .config, Kconfig files, tools/, arch-specific files)
- Generate configuration files during build using modules_prepare
- Create proper symlink from /lib/modules/{version}/build to headers directory

CI/CD:
- Use ubuntu-24.04-arm runner for native ARM64 builds cutting build time in half.
- Add debootstrap for chroot environment

## Testing

<!-- *Please explain how you tested this change manually, and if applicable, what new tests you added.* -->

Tested on a WLAN Pi Go:

- Simple hello world kernel module compilation and testing
- Complex module with proc fs, memory allocation, kernel APIs
- Real-world driver (rtl8812au) builds and loads successfully
- 19,206 kernel symbols available in Module.symvers
- All critical headers present (netdevice.h, cfg80211.h, usb.h, crypto/)

## LLM/AI usage

<!-- *Please disclose any use of LLMs or AI coding assistants in creating this PR.* -->

- [X] I used an LLM or AI coding assistant for this PR
- If yes, please describe:
  - Which tool(s) and model(s) were used (e.g., Gemini 2.5 Flash, Claude 4.5 Sonnet, Copilot GPT-4, ChatGPT GPT-5)? Sonnet 4.5
  - What portions of the code and PR were assisted?
  - Have you reviewed and tested all generated code for correctness?

## Checklist

<!-- No PR without a related GH issue! Conversations about your PR efforts in other channels such as electronic mail, social media, morse code, homing pigeon, or slack are great starting points, but **do not count** for this requirement. --> 

* [X] I have read the [contribution guidelines and policies](https://github.com/WLAN-Pi/.github/blob/main/docs/contributing.md)
* [X] I have targeted this PR against the correct git branch (this can vary depending on the default branch of the repo)
* [ ] I ran the test suite and verified it succeeded
* [ ] I linked a GitHub issue to this PR (in the next section). 
* [ ] I have updated the changelog (if applicable)
* [ ] I have added or updated the documentation (if applicable)

## Related Issues/PRs

<!-- *Pick at least one. Delete the other lines.* -->

- This PR fixes/closes issue #21 
- This PR is related to issue #
- This PR depends on/blocks PR #