### PR TITLE
Update actions to current majors (Node 20 deprecation)

### DIFF
--- a/.github/workflows/build-and-archive-kernel-package.yml
+++ b/.github/workflows/build-and-archive-kernel-package.yml
@@ -35,13 +35,13 @@ jobs:
     steps:
       # Step 1: Checkout the repository
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       # Step 2: Restore APT cache
       - name: Restore APT cache
-        uses: actions/cache@v3
+        uses: actions/cache@v6
         with:
           path: cache-apt
           key: ${{ runner.os }}-apt-${{ hashFiles('**/build-kernel.sh') }}
@@ -64,7 +64,7 @@ jobs:
 
       # Step 5: Cache kernel build directory
       - name: Cache kernel build directory
-        uses: actions/cache@v3
+        uses: actions/cache@v6
         with:
           path: linux
           key: ${{ runner.os }}-kernel-${{ env.BUILD_TARGET }}-${{ hashFiles('**/build-kernel.sh') }}
@@ -122,7 +122,7 @@ jobs:
       # Step 10: Upload v8 kernel package
       - name: Upload v8 kernel package
         if: ${{ env.BUILD_TARGET == 'v8' || env.BUILD_TARGET == 'both' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: wlanpi-kernel-bookworm-v8
           path: output/wlanpi-kernel-bookworm-v8_*.deb
@@ -131,7 +131,7 @@ jobs:
       # Step 11: Upload v8 headers package
       - name: Upload v8 headers package
         if: ${{ env.BUILD_TARGET == 'v8' || env.BUILD_TARGET == 'both' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: wlanpi-kernel-headers-bookworm-v8
           path: output/wlanpi-kernel-headers-bookworm-v8_*.deb
@@ -140,7 +140,7 @@ jobs:
       # Step 12: Upload 2712 kernel package
       - name: Upload 2712 Kernel Package
         if: ${{ env.BUILD_TARGET == '2712' || env.BUILD_TARGET == 'both' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: wlanpi-kernel-bookworm-2712
           path: output/wlanpi-kernel-bookworm-2712_*.deb
@@ -149,7 +149,7 @@ jobs:
       # Step 13: Upload 2712 headers package
       - name: Upload 2712 headers package
         if: ${{ env.BUILD_TARGET == '2712' || env.BUILD_TARGET == 'both' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: wlanpi-kernel-headers-bookworm-2712
           path: output/wlanpi-kernel-headers-bookworm-2712_*.deb
@@ -158,7 +158,7 @@ jobs:
       # Step 14: Upload dual kernel package
       - name: Upload dual kernel package
         if: ${{ env.BUILD_TARGET == 'both' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: wlanpi-kernel-bookworm-dual
           path: output/wlanpi-kernel-bookworm_*.deb


### PR DESCRIPTION
Part of the org-wide actions audit. Bumps outdated actions to current majors to clear the Node 20 deprecation warnings:

- actions/checkout to v7
- actions/upload-artifact to v7
- actions/cache to v6 (where used)
- actions/setup-python to v6 (where used)
- github/codeql-action to v4 (where used)

Workflow YAML validated. No behavior changes intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
